### PR TITLE
Add City Repo Event Issue Template

### DIFF
--- a/gittogethers/saopaulo/.github/ISSUE_TEMPLATE/event-issue-template.md
+++ b/gittogethers/saopaulo/.github/ISSUE_TEMPLATE/event-issue-template.md
@@ -1,0 +1,38 @@
+---
+name: Event Issue
+about: Create an issue to propose or plan a new GitTogether event.
+title: GitTogether City Name
+labels: event
+assignees: ''
+
+---
+
+## Event Theme. (if available)
+
+
+## Date
+
+
+## Time
+
+
+## Venue
+[Name of Co-working Space or Tech Company Office]
+
+## How to Reach
+[Provide detailed directions, including public transport options if applicable]
+
+## Event Banner
+[Event Banner]
+
+## Description
+
+
+## Agenda
+
+
+## Call for Speakers
+[Link to Google Form]
+
+## Registration Link
+[Link to the Meetup Registration] ✨


### PR DESCRIPTION
Adds a new issue template for organizing GitTogether events in the `gittogethers/saopaulo` repository.
- Creates a file named `event-issue-template.md` in the `.github/ISSUE_TEMPLATE` directory.
- The template includes sections for event theme, date, time, venue, directions, event banner, description, agenda, call for speakers, and registration link, aligning with the task's requirements for detailed event planning.
- Utilizes placeholders for elements like the venue name, directions, event banner, and links to ensure easy customization for different events.

